### PR TITLE
Updated loader to support multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Config
 
-**Config** provides a simple way to load configuration values from different sources using tags. 
+**Config** provides a simple way to load configuration values from different sources using tags.
 
 ```go
 package main
@@ -14,10 +14,10 @@ import (
 
 type Settings struct {
 	BaseURL        string `env:"BASE_URL"`
-	LogLevel       string `env:"LOG_LEVEL,optional"`
+	LogLevel       string `env:"LOG_LEVEL"`
 	MaxConnections int8   `env:"MAX_CONNECTIONS" default:"2"`
-	DisableSSL     bool   `env:"DISABLE_SSL,optional"`
-	JWTSecret      string `ssm:"jwt_secret"`
+	DisableSSL     bool   `env:"DISABLE_SSL" default:""`
+	JWTSecret      string `ssm:"jwt_secret" env:"JWT_SECRET"`
 }
 
 func main() {
@@ -48,6 +48,56 @@ func main() {
 - Fields can have default values
 - Add your own sources
 
+## Reading values
+
+You can specify multiple sources for the same variable:
+
+```go
+type Settings struct {
+	A string 	`env:"VALUE_A" ssm:"value_a"`
+	B int 		`ssm:"value_b" env:"VALUE_B" default:""`
+	C string 	`env:"VALUE_C" default:"hello"`
+}
+```
+
+The order in which the parameters will be loaded is defined by how you setup the sources. For instance:
+
+```go
+l := config.NewLoader(config.NewSSMSource(), config.NewEnvSource())
+```
+
+will load the values from SSM first and then use the environment. If you consider the type above:
+
+- `A`: will load the parameter `value_a` from SSM, then `VALUE_A` from the environment. If `VALUE_A` is set,
+  it will replace the initial value set from SSM. If both `value_a` and `VALUE_A` are not set, the loader will fail since there is no default.
+- `B`: same as before (not that the order of the tags is irrelevant). The difference is that if both `value_b` and `VALUE_B` are not set, `B` will be
+  set to the zero value (0 in this case) and the loader won't fail. This is how you can define something as optional.
+- `C`: will get `VALUE_C` from the environment and if not set, will use `hello` as default.
+
+### Deprecated optional flag
+
+Earlier version of this package supported an `optional` flag to denote that a source was not required. This flag is not deprecated and should be replaced with `default:""`:
+
+```go
+type OldSettings struct {
+	Key string `env:"VALUE,optional"`
+}
+
+type NewSettings struct {
+	Key string `env:"VALUE" default:""`
+}
+```
+
+This is because it now supports multiple sources and the following would be undefined:
+
+```go
+type Settings struct {
+	Key string `env:"VALUE,optional" ssm:"value"`
+}
+```
+
+In order to be retro-compatible, you can still use the `optional` flag and it will be taken into account only with one source.
+
 ## Available sources
 
 ### Environment
@@ -73,7 +123,13 @@ s = config.NewSSMSourceWithClient(svc)
 
 creates a new `Source` that loads values from SSM using [GetParameter](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#SSM.GetParameter). Note that you must have permissions to get the parameters from SSM.
 
-Tag with `ssm` to load values from SSM.
+Tag with `ssm` to load values from SSM. You can use `secure` to load a secure string:
+
+```go
+type Settings struct {
+	Key string `ssm:"api_key,secure"`
+}
+```
 
 ## Custom sources
 
@@ -82,19 +138,19 @@ A `Source` is an interface that loads values from a location:
 ```go
 type Source interface {
 	Tag() string
-	Get(key string) (string, error)
+	Get(TagValue) (string, error)
 }
 ```
 
 where:
 
-```go 
+```go
 func Tag() string
 ```
 
 returns the name of the tag linked to this source. For instance, [EnvSource](./env.go) returns `"env"` so that fields tagged with `"env:NAME"` will be loaded using this source.
 
-```go 
+```go
 func Get(key string) (string, error)
 ```
 

--- a/loader_test.go
+++ b/loader_test.go
@@ -2,16 +2,21 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 	"testing"
 )
 
 type testSource struct {
+	tag    string
 	values map[string]string
 }
 
 func (ts *testSource) Tag() string {
-	return "test"
+	if ts.tag == "" {
+		return "test"
+	}
+	return ts.tag
 }
 func (ts *testSource) Get(tag TagValue) (string, error) {
 	v, found := ts.values[tag.Name]
@@ -21,7 +26,7 @@ func (ts *testSource) Get(tag TagValue) (string, error) {
 	return v, nil
 }
 
-func TestA(t *testing.T) {
+func Test_SingleSource(t *testing.T) {
 	testCases := []struct {
 		desc   string
 		v      interface{}
@@ -57,7 +62,7 @@ func TestA(t *testing.T) {
 			values: map[string]string{
 				"ttt": "",
 			},
-			err: "config: missing value for key 'ttt'",
+			err: "config: missing value for field 'T'",
 		},
 		{
 			desc: "error getting value",
@@ -65,19 +70,7 @@ func TestA(t *testing.T) {
 				T string `test:"ttt"`
 			}{},
 			values: map[string]string{},
-			err:    "error getting key ttt",
-		},
-		{
-			desc: "does not fail when optional fields are not set",
-			v: &struct {
-				T string `test:"ttt,optional"`
-			}{},
-			values: map[string]string{
-				"ttt": "",
-			},
-			out: &struct {
-				T string `test:"ttt,optional"`
-			}{},
+			err:    "config: error loading field T for tag test: error getting key ttt",
 		},
 		{
 			desc: "ignores fields without a known tag",
@@ -89,21 +82,32 @@ func TestA(t *testing.T) {
 			}{},
 		},
 		{
+			desc: "error for unsupported types",
+			v: &struct {
+				T io.Reader `test:"reader"`
+			}{},
+			err: "config: field type Reader is not supported",
+		},
+		{
 			desc: "string field",
 			v: &struct {
 				T string `test:"field"`
 				D string `test:"other" default:"venice"`
+				Q string `test:"hello" default:""`
 			}{},
 			values: map[string]string{
 				"field": "hello",
 				"other": "",
+				"hello": "",
 			},
 			out: &struct {
 				T string `test:"field"`
 				D string `test:"other" default:"venice"`
+				Q string `test:"hello" default:""`
 			}{
 				T: "hello",
 				D: "venice",
+				Q: "",
 			},
 		},
 		{
@@ -117,6 +121,7 @@ func TestA(t *testing.T) {
 				D1 bool `test:"other1" default:"true"`
 				D2 bool `test:"other2" default:"1"`
 				D3 bool `test:"other3" default:"0"`
+				D4 bool `test:"other4" default:""`
 			}{},
 			values: map[string]string{
 				"field1": "true",
@@ -127,6 +132,7 @@ func TestA(t *testing.T) {
 				"other1": "",
 				"other2": "",
 				"other3": "",
+				"other4": "",
 			},
 			out: &struct {
 				T1 bool `test:"field1"`
@@ -137,6 +143,7 @@ func TestA(t *testing.T) {
 				D1 bool `test:"other1" default:"true"`
 				D2 bool `test:"other2" default:"1"`
 				D3 bool `test:"other3" default:"0"`
+				D4 bool `test:"other4" default:""`
 			}{
 				T1: true,
 				T2: true,
@@ -146,6 +153,7 @@ func TestA(t *testing.T) {
 				D1: true,
 				D2: true,
 				D3: false,
+				D4: false,
 			},
 		},
 		{
@@ -181,6 +189,7 @@ func TestA(t *testing.T) {
 				D3 int16 `test:"other3" default:"93"`
 				D4 int8  `test:"other4" default:"94"`
 				D5 int   `test:"other5" default:"95"`
+				D6 int   `test:"other5" default:""`
 			}{},
 			values: map[string]string{
 				"field1": "11",
@@ -193,6 +202,7 @@ func TestA(t *testing.T) {
 				"other3": "",
 				"other4": "",
 				"other5": "",
+				"other6": "",
 			},
 			out: &struct {
 				T1 int64 `test:"field1"`
@@ -205,6 +215,7 @@ func TestA(t *testing.T) {
 				D3 int16 `test:"other3" default:"93"`
 				D4 int8  `test:"other4" default:"94"`
 				D5 int   `test:"other5" default:"95"`
+				D6 int   `test:"other5" default:""`
 			}{
 				T1: 11,
 				T2: 22,
@@ -216,14 +227,13 @@ func TestA(t *testing.T) {
 				D3: 93,
 				D4: 94,
 				D5: 95,
+				D6: 0,
 			},
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			l := NewLoader(&testSource{
-				values: tC.values,
-			})
+			l := NewLoader(&testSource{values: tC.values})
 			err := l.Load(tC.v)
 			errMsg := ""
 			if err != nil {
@@ -236,5 +246,123 @@ func TestA(t *testing.T) {
 				t.Errorf("expected output to be %v but was %v", tC.out, tC.v)
 			}
 		})
+	}
+}
+
+func Test_MultipleSources(t *testing.T) {
+	testCases := []struct {
+		desc string
+		v    interface{}
+		s1   Source
+		s2   Source
+		out  interface{}
+		err  string
+	}{
+		{
+			desc: "error with first source stops processing",
+			v: &struct {
+				T string `test:"a" happy:"b"`
+			}{},
+			s1:  &testSource{tag: "test", values: map[string]string{}},
+			s2:  &testSource{tag: "happy", values: map[string]string{"b": "hello"}},
+			err: "config: error loading field T for tag test: error getting key a",
+		},
+		{
+			desc: "missing value in all sources",
+			v: &struct {
+				T string `test:"a" happy:"b" json:"x"`
+			}{},
+			s1:  &testSource{tag: "test", values: map[string]string{"a": ""}},
+			s2:  &testSource{tag: "happy", values: map[string]string{"b": ""}},
+			err: "config: missing value for field 'T'",
+		},
+		{
+			desc: "sources are evaluated in sequence",
+			v: &struct {
+				T string `test:"a" happy:"b"`
+			}{},
+			s1: &testSource{tag: "test", values: map[string]string{"a": "replaced"}},
+			s2: &testSource{tag: "happy", values: map[string]string{"b": "hello"}},
+			out: &struct {
+				T string `test:"a" happy:"b"`
+			}{
+				T: "hello",
+			},
+		},
+		{
+			desc: "default is ignored when one source provides value",
+			v: &struct {
+				T string `test:"a" happy:"b" default:"ignored"`
+			}{},
+			s1: &testSource{tag: "test", values: map[string]string{"a": "replaced"}},
+			s2: &testSource{tag: "happy", values: map[string]string{"b": "hello"}},
+			out: &struct {
+				T string `test:"a" happy:"b" default:"ignored"`
+			}{
+				T: "hello",
+			},
+		},
+		{
+			desc: "default is used when no sources provide a value",
+			v: &struct {
+				T string `test:"a" happy:"b" default:"actual"`
+			}{},
+			s1: &testSource{tag: "test", values: map[string]string{"a": ""}},
+			s2: &testSource{tag: "happy", values: map[string]string{"b": ""}},
+			out: &struct {
+				T string `test:"a" happy:"b" default:"actual"`
+			}{
+				T: "actual",
+			},
+		},
+		{
+			desc: "empty default makes field optional",
+			v: &struct {
+				T string `test:"a" happy:"b" default:""`
+			}{},
+			s1: &testSource{tag: "test", values: map[string]string{"a": ""}},
+			s2: &testSource{tag: "happy", values: map[string]string{"b": ""}},
+			out: &struct {
+				T string `test:"a" happy:"b" default:""`
+			}{},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			l := NewLoader(tC.s1, tC.s2)
+			err := l.Load(tC.v)
+			errMsg := ""
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if errMsg != tC.err {
+				t.Fatalf("expected error to be '%s' but was '%s'", tC.err, errMsg)
+			}
+			if tC.err == "" && !reflect.DeepEqual(tC.out, tC.v) {
+				t.Errorf("expected output to be %v but was %v", tC.out, tC.v)
+			}
+		})
+	}
+}
+
+func Test_DeprecatedOptionalFlag(t *testing.T) {
+	l := NewLoader(&testSource{
+		tag: "test",
+		values: map[string]string{
+			"ttt": "",
+		},
+	})
+
+	v := struct {
+		T string `test:"ttt,optional"`
+	}{}
+	out := v
+
+	err := l.Load(&v)
+	if err != nil {
+		t.Fatalf("expected error to be nil but was '%s'", err.Error())
+	}
+	if !reflect.DeepEqual(out, v) {
+		t.Errorf("expected output to be %v but was %v", out, v)
 	}
 }


### PR DESCRIPTION
This PR closes #4 adding support for multiple sources and deprecating the `optional` flag which has been replaced by an empty default value.